### PR TITLE
Fix VTK 9 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ INCLUDE_DIRECTORIES (${HDF5_INCLUDE_DIRS})
 # vtk
 find_package(VTK REQUIRED COMPONENTS vtkIOGeometry NO_MODULE)
 if (${VTK_VERSION} VERSION_GREATER "9")
-    find_package(VTK REQUIRED COMPONENTS CommonCore NO_MODULE)
+    find_package(VTK REQUIRED COMPONENTS CommonCore GUISupportQt NO_MODULE)
 else()
     find_package(VTK REQUIRED)
 endif()

--- a/main.cpp
+++ b/main.cpp
@@ -18,7 +18,10 @@
 #include "AppCSXCAD.h"
 
 #include "vtkCommand.h"
-#if VTK_MAJOR_VERSION>=8
+#include "vtkVersion.h"
+#if VTK_MAJOR_VERSION>=9
+  #include <QVTKOpenGLNativeWidget.h>
+#elif VTK_MAJOR_VERSION==8
   #include <QVTKOpenGLWidget.h>
   #include <QSurfaceFormat>
 #endif
@@ -26,8 +29,10 @@
 
 int main(int argc, char *argv[])
 {
-#if VTK_MAJOR_VERSION>=8
-    QSurfaceFormat::setDefaultFormat(QVTKOpenGLWidget::defaultFormat());
+#if VTK_MAJOR_VERSION>=9
+	QSurfaceFormat::setDefaultFormat(QVTKOpenGLNativeWidget::defaultFormat());
+#elif VTK_MAJOR_VERSION==8
+	QSurfaceFormat::setDefaultFormat(QVTKOpenGLWidget::defaultFormat());
 #endif
 #if not defined(__WIN32) && not defined(__WIN64)
 	//prevent that Qt changes float handling, e.g. expecting a german 1,345e+3 will fail...


### PR DESCRIPTION
Would not build with VTK 9. Other files got a similar update previously but main.cpp was left out.