### PR TITLE
CI: Fix AlmaLinux 9 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,19 @@ jobs:
             ancient: false
             docker-image: "almalinux:8"
 
-          - name: "AlmaLinux Latest"
+          - name: "AlmaLinux 9"
             libc: "GNU"
             ancient: false
-            docker-image: "almalinux:latest"
+            docker-image: "almalinux:9"
+
+          # Waiting for upstream packages:
+          # https://bugzilla.redhat.com/show_bug.cgi?id=2374130
+          # https://bugzilla.redhat.com/show_bug.cgi?id=2419727
+          #
+          #- name: "AlmaLinux Latest"
+          #  libc: "GNU"
+          #  ancient: false
+          #  docker-image: "almalinux:latest"
 
           # Alpine has no VTK Qt support, disabled.
           #- name: "Alpine"


### PR DESCRIPTION
## See Also

* https://github.com/thliebig/CSXCAD/pull/76
* https://github.com/thliebig/openEMS/pull/201
* https://github.com/thliebig/openEMS-Project/pull/419

## Introduction

Previously AlmaLinux 9 failed to build because of an upstream bug [1], just after this bug has been fixed, AlmaLinux 9 still failed to build because GitHub Actions upgraded "AlmaLinux Latest" from AlmaLinux 9 to 10, and AlmaLinux 10 has two additional missing packages (reported as bugs [2][3]).

To fix the build for now, change "AlmaLinux Latest" to "AlmaLinux 9".

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2416611
[2] https://bugzilla.redhat.com/show_bug.cgi?id=2374130
[3] https://bugzilla.redhat.com/show_bug.cgi?id=2419727