### PR TITLE
main.cpp: fix incorrect Windows detection macros.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
 #elif VTK_MAJOR_VERSION==8
 	QSurfaceFormat::setDefaultFormat(QVTKOpenGLWidget::defaultFormat());
 #endif
-#if not defined(__WIN32) && not defined(__WIN64)
+#if !defined(_WIN32) && !defined(_WIN64)
 	//prevent that Qt changes float handling, e.g. expecting a german 1,345e+3 will fail...
 	setenv("LC_NUMERIC","C",1);
 #endif


### PR DESCRIPTION
To detect Windows, the `_WIN32` and `_WIN64` C macro contain one underscore, not two underscores. The keyword `not` is also an ISO 646 alias to `!`, so its use is discouraged.